### PR TITLE
support older requests lib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -310,7 +310,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "types-requests"
-version = "2.27.30"
+version = "2.27.31"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -359,7 +359,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d694693216a41e45c4d9af7aa8538d6328ed3fbf768a1440d7d71ec4611126ec"
+content-hash = "663271ad025a46abcc313f824d8588b99ebe2b38bd46d1d4fe7395d9a86ff71a"
 
 [metadata.files]
 atomicwrites = [
@@ -517,8 +517,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 types-requests = [
-    {file = "types-requests-2.27.30.tar.gz", hash = "sha256:ca8d7cc549c3d10dbcb3c69c1b53e3ffd1270089c1001a65c1e9e1017eb5e704"},
-    {file = "types_requests-2.27.30-py3-none-any.whl", hash = "sha256:b9b6cd0a6e5d500e56419b79f44ec96f316e9375ff6c8ee566c39d25e9612621"},
+    {file = "types-requests-2.27.31.tar.gz", hash = "sha256:6fab97b99fea52b9c7b466a4dd93e06bb325bc7e7420475e87831026a8dd35cc"},
+    {file = "types_requests-2.27.31-py3-none-any.whl", hash = "sha256:1b6cf6a2bf57fd8018c1b636b69762900466fafddfb62e1330e092f3d4b0966a"},
 ]
 types-urllib3 = [
     {file = "types-urllib3-1.26.15.tar.gz", hash = "sha256:c89283541ef92e344b7f59f83ea9b5a295b16366ceee3f25ecfc5593c79f794e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Karl Fischer <kfischer@redhat.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-requests = "^2.28"
+requests = "^2.22"
 graphql-core = "^3.2"
 
 [tool.poetry.dev-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ package_data = \
 {'': ['*']}
 
 install_requires = \
-['graphql-core>=3.2,<4.0', 'requests>=2.28,<3.0']
+['graphql-core>=3.2,<4.0', 'requests>=2.22,<3.0']
 
 entry_points = \
 {'console_scripts': ['qenerate = qenerate.cli:run']}


### PR DESCRIPTION
Our qontract-reconcile requires requests `2.22`.